### PR TITLE
Watch webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ module.exports = {
   }
 };
 ```
+
+## Watch
+
+At the moment, the Elm compiler doesn't give any options to retrieve the
+imported Elm files. To support `webpack --watch`, this loader adds all `.elm`
+files in the path of the webpack entry file.

--- a/index.js
+++ b/index.js
@@ -4,11 +4,21 @@ var _           = require('lodash');
 var compile     = require("node-elm-compiler").compile;
 var loaderUtils = require("loader-utils");
 var fs          = require("fs");
+var path        = require('path');
+var glob        = require('glob');
 
 var defaultOptions = {
   yes: true,
   output: "tmp/[name].js"
 };
+
+var addDependencies = function (basePath, addDependency) {
+  glob(basePath + "/**/*.elm", function (err, files) {
+    for (var i = 0; i < files.length; i++) {
+      addDependency(files[i]);
+    }
+  });
+}
 
 module.exports = function(source) {
   this.cacheable && this.cacheable();
@@ -34,6 +44,7 @@ module.exports = function(source) {
   var compileOpts = _.defaults({ output: output, warn: emitWarning }, options, defaultOptions);
 
   try {
+    addDependencies(path.dirname(sourceFiles), this.addDependency);
     compile(sourceFiles, compileOpts).on("close", function(output, exitCode) {
       if (exitCode === 0) {
         fs.readFile(output, "utf8", function(err, result) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/rtfeldman/elm-webpack-loader",
   "dependencies": {
+    "glob": "^6.0.1",
     "loader-utils": "0.2.11",
     "lodash": "3.10.1",
     "node-elm-compiler": "2.2.0"


### PR DESCRIPTION
This implementation adds all elm files in the path of the webpack entry file and adds these as a dependency to webpack.

This implementation is naive as it loads all files in the path of the entry module. I've seen the implementation of https://gist.github.com/rtfeldman/db7b121100b6c6ff435b but I'm not sure it adds a lot of value at the moment.

I'm going to see if it's necessary to update the example.