### PR TITLE
Improve example and readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ node_modules/
 tmp/
 /elm-package.json
 /test/expected/*
+/test/fixtures/elm-package.json
 !/test/expected/.keep

--- a/README.md
+++ b/README.md
@@ -27,3 +27,29 @@ module.exports = {
   }
 };
 ```
+
+## Notes
+
+### Example
+
+You can find an example in the `example` folder.
+To run:
+
+```
+npm install
+npm run build
+```
+
+or run with `npm run watch` to use `webpack --watch`.
+
+### noParse
+
+Webpack can complain about precompiled files (files compiled by `elm-make`).
+You can silence this warning with (noParse)[https://webpack.github.io/docs/configuration.html#module-noparse]. You can see it in use in the example.
+
+```js
+  module: {
+    loaders: [...],
+    noParse: [/.elm$/]
+  }
+```

--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,8 @@
   "license": "BSD-3-Clause",
   "private": true,
   "scripts": {
-    "build": "webpack"
+    "build": "webpack",
+    "watch": "webpack --watch"
   },
   "dependencies": {
     "webpack": "^1.12.0",

--- a/example/src/Hello/World.elm
+++ b/example/src/Hello/World.elm
@@ -1,0 +1,3 @@
+module Hello.World where
+
+hello = "Hello, World!"

--- a/example/src/HelloWorld.elm
+++ b/example/src/HelloWorld.elm
@@ -1,6 +1,0 @@
-module HelloWorld where
-
-import Html exposing (text)
-
-main =
-  text "Hello, World!"

--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -1,0 +1,5 @@
+import Html exposing (text)
+import Hello.World exposing (hello)
+
+main =
+  text hello

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
 require('./index.html');
-var Elm = require('./HelloWorld');
+var Elm = require('./Main');
 
-Elm.fullscreen(Elm.HelloWorld);
+Elm.fullscreen(Elm.Main);


### PR DESCRIPTION
This fixes the example completely and adds some more info to the README. The Hello/World module structure is a bit contrived, but it makes it easier to demonstrate `webpack --watch`