### PR TITLE
Webpack watch v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ module.exports = {
 };
 ```
 
+### Options
+
+#### Cache (default false)
+
+You can add `cache=true` to the loader:
+
+```js
+  ...
+  loader: 'elm-webpack?cache=true'
+  ...
+```
+
+If you add this, when using `npm run watch`, the loader will only load the
+dependencies at startup. This could be performance improvement, but know that
+new files won't be picked up and so won't be watched until you restart webpack.
+
+This flag doesn't matter if you don't use watch mode.
+
 ## Notes
 
 ### Example

--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "webpack": "^1.12.0",
-    "file-loader": "^0.8.0",
-    "elm-webpack-loader": "../"
+    "file-loader": "^0.8.0"
   }
 }

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
       {
         test: /\.elm$/,
         exclude: [/elm-stuff/, /node_modules/],
-        loader: 'elm-webpack'
+        loader: '../../index.js'
       }
     ],
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
 'use strict';
 
-var _                   = require('lodash');
-var compile             = require("node-elm-compiler").compileToString;
-var findAllDependencies = require('node-elm-compiler').findAllDependencies;
-var fs                  = require("fs");
-var loaderUtils         = require("loader-utils");
+var _            = require('lodash');
+var elmCompiler  = require("node-elm-compiler");
+var fs           = require("fs");
+var loaderUtils  = require("loader-utils");
 
 var defaultOptions = {
   yes: true,
@@ -34,13 +33,13 @@ module.exports = function(source) {
 
   var compileOpts = _.defaults({ output: output, warn: emitWarning }, options, defaultOptions);
 
-  findAllDependencies(sourceFiles).then(function(dependencies) {
+  elmCompiler.findAllDependencies(sourceFiles).then(function(dependencies) {
     for (var i = 0; i < dependencies.length; i++) {
       this.addDependency(dependencies[i]);
     }
   }.bind(this));
 
-  compile(sourceFiles, compileOpts).then(function(result) {
+  elmCompiler.compileToString(sourceFiles, compileOpts).then(function(result) {
     var resultWithExports = [result, "module.exports = Elm;"].join("\n");
     callback(null, resultWithExports);
   }, function(err) {

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 'use strict';
 
-var _           = require('lodash');
-var compile     = require("node-elm-compiler").compileToString;
-var loaderUtils = require("loader-utils");
-var fs          = require("fs");
+var _                   = require('lodash');
+var compile             = require("node-elm-compiler").compileToString;
+var findAllDependencies = require('node-elm-compiler').findAllDependencies;
+var fs                  = require("fs");
+var loaderUtils         = require("loader-utils");
 
 var defaultOptions = {
   yes: true,
@@ -32,6 +33,12 @@ module.exports = function(source) {
   });
 
   var compileOpts = _.defaults({ output: output, warn: emitWarning }, options, defaultOptions);
+
+  findAllDependencies(sourceFiles).then(function(dependencies) {
+    for (var i = 0; i < dependencies.length; i++) {
+      this.addDependency(dependencies[i]);
+    }
+  }.bind(this));
 
   compile(sourceFiles, compileOpts).then(function(result) {
     var resultWithExports = [result, "module.exports = Elm;"].join("\n");


### PR DESCRIPTION
This version uses `findAllDependencies`.
It doesn't cache at the moment, so it calls `addDependency` on every change. The advantage is that new files are also picked up.

A possible disadvantage is that this is a bit slower (possible for large projects). I wouldn't worry about this at the moment, but if this is a problem for some, we could at caching as an option.