### PR TITLE
Improve tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+elm-stuff/**
+test/fixtures/**

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,87 @@
+{
+  "rules": {
+    // disallow trailing commas in object literals
+    "comma-dangle": [2, "never"],
+    // specify whether double or single quotes should be used
+    'quotes': [2, "single"],
+    // disallow assignment in conditional expressions
+    "no-cond-assign": [2, "always"],
+    // disallow use of console
+    "no-console": 1,
+    // disallow use of constant expressions in conditions
+    "no-constant-condition": 1,
+    // disallow control characters in regular expressions
+    "no-control-regex": 2,
+    // disallow use of debugger
+    "no-debugger": 1,
+    // disallow duplicate arguments in functions
+    "no-dupe-args": 2,
+    // disallow duplicate keys when creating object literals
+    "no-dupe-keys": 2,
+    // disallow a duplicate case label.
+    "no-duplicate-case": 2,
+    // disallow the use of empty character classes in regular expressions
+    "no-empty-character-class": 2,
+    // disallow empty statements
+    "no-empty": 2,
+    // disallow assigning to the exception in a catch block
+    "no-ex-assign": 2,
+    // disallow double-negation boolean casts in a boolean context
+    "no-extra-boolean-cast": 0,
+    // disallow unnecessary parentheses
+    "no-extra-parens": [2, "functions"],
+    // disallow unnecessary semicolons
+    "no-extra-semi": 2,
+    // disallow overwriting functions written as function declarations
+    "no-func-assign": 2,
+    // disallow function or variable declarations in nested blocks
+    "no-inner-declarations": 2,
+    // disallow invalid regular expression strings in the RegExp constructor
+    "no-invalid-regexp": 2,
+    // disallow irregular whitespace outside of strings and comments
+    "no-irregular-whitespace": 2,
+    // disallow negation of the left operand of an in expression
+    "no-negated-in-lhs": 2,
+    // disallow the use of object properties of the global object (Math and JSON) as functions
+    "no-obj-calls": 2,
+    // disallow multiple spaces in a regular expression literal
+    "no-regex-spaces": 2,
+    // disallow sparse arrays
+    "no-sparse-arrays": 2,
+    // disallow unreachable statements after a return, throw, continue, or break statement
+    "no-unreachable": 2,
+    // disallow comparisons with the value NaN
+    "use-isnan": 2,
+    // ensure JSDoc comments are valid
+    "valid-jsdoc": 0,
+    // ensure that the results of typeof are compared against a valid string
+    "valid-typeof": 2,
+    // Avoid code that looks like two expressions but is actually one
+    "no-unexpected-multiline": 0,
+    // enforce or disallow variable initializations at definition
+    "init-declarations": 0,
+    // disallow the catch clause parameter name being the same as a variable in the outer scope
+    "no-catch-shadow": 0,
+    // disallow deletion of variables
+    "no-delete-var": 2,
+    // disallow labels that share a name with a variable
+    "no-label-var": 0,
+    // disallow shadowing of names such as arguments
+    "no-shadow-restricted-names": 2,
+    // disallow declaration of variables already declared in the outer scope
+    "no-shadow": 2,
+    // disallow use of undefined when initializing variables
+    "no-undef-init": 0,
+    // disallow use of undeclared variables unless mentioned in a /*global */ block
+    "no-undef": 2,
+    // disallow use of undefined variable
+    "no-undefined": 0,
+    // disallow declaration of variables that are not used in the code
+    "no-unused-vars": [2, {"vars": "local", "args": "after-used"}],
+    // disallow use of variables before they are defined
+    "no-use-before-define": 2
+  },
+  "env": {
+    "node": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,2 @@
 elm-stuff/
 node_modules/
-tmp/
-/elm-package.json
-/test/expected/*
-/test/fixtures/elm-package.json
-!/test/expected/.keep

--- a/example/.eslintrc
+++ b/example/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "browser": true
+  }
+}

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -1,5 +1,3 @@
-var path = require('path');
-
 module.exports = {
   entry: './src/index.js',
 

--- a/index.js
+++ b/index.js
@@ -1,18 +1,34 @@
 'use strict';
 
-var _            = require('lodash');
-var elmCompiler  = require('node-elm-compiler');
-var loaderUtils  = require('loader-utils');
-
-var defaultOptions = {
-  cache: false,
-  yes: true,
-  output: '[name].js'
-};
+var _ = require('lodash');
+var loaderUtils = require('loader-utils');
+var elmCompiler = require('node-elm-compiler');
 
 var cachedDependencies = [];
 
-module.exports = function(source) {
+var defaultOptions = {
+  cache: false,
+  yes: true
+};
+
+var getInput = function() {
+  return loaderUtils.getRemainingRequest(this);
+};
+
+var getOptions = function() {
+  var globalOptions = this.options.elm || {};
+  var loaderOptions = loaderUtils.parseQuery(this.query);
+  return _.extend({
+    warn: this.emitWarning
+  }, defaultOptions, globalOptions, loaderOptions);
+};
+
+var addDependencies = function(dependencies) {
+  cachedDependencies = dependencies;
+  dependencies.forEach(this.addDependency.bind(this));
+};
+
+module.exports = function() {
   this.cacheable && this.cacheable();
 
   var callback = this.async();
@@ -21,34 +37,19 @@ module.exports = function(source) {
     throw 'elm-webpack-loader currently only supports async mode.'
   }
 
-  var emitWarning = this.emitWarning.bind(this);
+  var input = getInput.call(this);
+  var options = getOptions.call(this);
 
-  var sourceFiles = loaderUtils.getRemainingRequest(this);
-  var options     = loaderUtils.parseQuery(this.query);
-
-  var output = loaderUtils.interpolateName(this, defaultOptions.output, {
-    context: options.context || this.options.context,
-    content: source,
-    regExp:  options.regExp
-  });
-
-  var compileOpts = _.defaults({ output: output, warn: emitWarning }, options, defaultOptions);
-  delete compileOpts.cache;
-
-  if (!options.cache || cachedDependencies.length == 0) {
-    elmCompiler.findAllDependencies(sourceFiles).then(function(dependencies) {
-      cachedDependencies = dependencies;
-      for (var i = 0; i < dependencies.length; i++) {
-        this.addDependency(dependencies[i]);
-      }
-    }.bind(this));
+  if (!options.cache || cachedDependencies.length === 0) {
+    elmCompiler.findAllDependencies(input).then(addDependencies.bind(this));
   }
 
-  elmCompiler.compileToString(sourceFiles, compileOpts).then(function(result) {
-    var resultWithExports = [result, 'module.exports = Elm;'].join('\n');
-    callback(null, resultWithExports);
-  }, function(exitCode) {
-    callback('Compiler process exited with code ' + exitCode);
-  });
-
+  elmCompiler.compileToString(input, options)
+    .then(function(result) {
+      var resultWithExports = [result, 'module.exports = Elm;'].join('\n');
+      callback(null, resultWithExports);
+    })
+    .catch(function(err) {
+      callback('Compiler process exited with error ' + err);
+    });
 }

--- a/index.js
+++ b/index.js
@@ -1,14 +1,13 @@
 'use strict';
 
 var _            = require('lodash');
-var elmCompiler  = require("node-elm-compiler");
-var fs           = require("fs");
-var loaderUtils  = require("loader-utils");
+var elmCompiler  = require('node-elm-compiler');
+var loaderUtils  = require('loader-utils');
 
 var defaultOptions = {
   cache: false,
   yes: true,
-  output: "[name].js"
+  output: '[name].js'
 };
 
 var cachedDependencies = [];
@@ -19,11 +18,10 @@ module.exports = function(source) {
   var callback = this.async();
 
   if (!callback) {
-    throw "elm-webpack-loader currently only supports async mode."
+    throw 'elm-webpack-loader currently only supports async mode.'
   }
 
   var emitWarning = this.emitWarning.bind(this);
-  var emitError   = this.emitError.bind(this);
 
   var sourceFiles = loaderUtils.getRemainingRequest(this);
   var options     = loaderUtils.parseQuery(this.query);
@@ -47,10 +45,10 @@ module.exports = function(source) {
   }
 
   elmCompiler.compileToString(sourceFiles, compileOpts).then(function(result) {
-    var resultWithExports = [result, "module.exports = Elm;"].join("\n");
+    var resultWithExports = [result, 'module.exports = Elm;'].join('\n');
     callback(null, resultWithExports);
-  }, function(err) {
-    callback("Compiler process exited with code " + exitCode);
+  }, function(exitCode) {
+    callback('Compiler process exited with code ' + exitCode);
   });
 
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Webpack loader for the Elm programming language.",
   "main": "index.js",
   "scripts": {
-    "test": "nodeunit test/loader.js"
+    "test": "mocha test/*.js"
   },
   "engines": {
     "node": ">=0.12.0"
@@ -30,6 +30,7 @@
     "node-elm-compiler": "^2.3.2"
   },
   "devDependencies": {
-    "nodeunit": "^0.9"
+    "chai": "^3.4.1",
+    "mocha": "^2.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Webpack loader for the Elm programming language.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha test/*.js"
+    "lint": "eslint .",
+    "test": "npm run lint && mocha test/*.js"
   },
   "engines": {
     "node": ">=0.12.0"
@@ -31,6 +32,7 @@
   },
   "devDependencies": {
     "chai": "^3.4.1",
-    "mocha": "^2.3.4"
+    "mocha": "^2.3.4",
+    "eslint": "^1.10.3"
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "jasmine": true
+  }
+}

--- a/test/fixtures/Good.elm
+++ b/test/fixtures/Good.elm
@@ -1,3 +1,5 @@
 module Good where
 
-add x y = x + y
+import GoodDependency exposing ( add )
+
+addSquares x y = add (x^2) (y^2)

--- a/test/fixtures/GoodDependency.elm
+++ b/test/fixtures/GoodDependency.elm
@@ -1,0 +1,3 @@
+module GoodDependency where
+
+add x y = x + y

--- a/test/fixtures/elm-package.json
+++ b/test/fixtures/elm-package.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.0.1",
+  "summary": "Tests for `elm-webpack-loader`.",
+  "repository": "https://github.com/rtfeldman/elm-webpack-loader.git",
+  "license": "BSD-3-Clause",
+  "source-directories": [
+    "."
+  ],
+  "exposed-modules": [
+  ],
+  "dependencies": {
+    "elm-lang/core": "3.0.0 <= v < 4.0.0"
+  },
+  "elm-version": "0.16.0 <= v < 0.17.0"
+}

--- a/test/loader.js
+++ b/test/loader.js
@@ -81,7 +81,7 @@ describe('async mode', function () {
   var context;
 
   // Download of Elm can take a while.
-  this.timeout(300000);
+  this.timeout(600000);
 
   it('compiles the resource', function (done) {
     var options = {

--- a/test/loader.js
+++ b/test/loader.js
@@ -1,4 +1,3 @@
-var fs = require('fs');
 var path = require('path');
 var crypto = require('crypto');
 var assert = require('chai').assert;


### PR DESCRIPTION
A few commits:

* Migrate tests to `mocha` and `chai`: that way it's easier to share knowledge between this project and `node-elm-compiler`.
* Lint all files: there were a bunch of unused variables, and references to undefined variables. We can discuss the specific rules if needed.
* Commit `elm-package.json`: as @rtfeldman recommended, we now use the `cwd` option to run the compiler inside the `test/fixtures` folder, so I've committed the corresponding `elm-package.json` instead of ignoring it.
* Test adding dependencies: we had added the functionality to watch dependencies, but there were no tests for it.

I've marked one test (`emits errors`) as pending, as it isn't really testing anything at the moment. `node-elm-compiler` outputs errors to `console.error`, but ideally we would be able to tell it to use webpack's `emitError` function. I'll create a pull request for `node-elm-compiler`, and once that's done I'll fix the pending test here.

@rtfeldman can you please review?