### PR TITLE
Adds option to specify elm project is not at root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ new files won't be picked up and so won't be watched until you restart webpack.
 
 This flag doesn't matter if you don't use watch mode.
 
+#### cwd (default null)
+
+You can add `cwd=elmSource` to the loader:
+```js
+var elmSource = __dirname + '/elm/path/in/project'
+  ...
+  loader: 'elm-webpack?cwd=' + elmSource
+  ...
+```
+
+You can use this to specify a custom location within your project for your elm files. Note, this
+will cause the compiler to look for **all** elm source files in the specified directory.
+
 ## Notes
 
 ### Example


### PR DESCRIPTION
Adds a loader option to specify that the elm project isn't at the root directory of the overall project.

I'm certainly not tied to any of the variable names or the readme description and am open to editing them.

Closes #27 