### PR TITLE
Upgrade node-elm-compiler to 3.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var getOptions = function() {
   var globalOptions = this.options.elm || {};
   var loaderOptions = loaderUtils.parseQuery(this.query);
   return _.extend({
-    warn: this.emitWarning
+    emitWarning: this.emitWarning
   }, defaultOptions, globalOptions, loaderOptions);
 };
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "loader-utils": "^0.2.11",
     "lodash": "^3.10.1",
-    "node-elm-compiler": "^2.3.3"
+    "node-elm-compiler": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
Enable the `warn` option. Fixes https://github.com/rtfeldman/elm-webpack-loader/issues/31

This would be a breaking change to what the `warn` option does, so it will be a bump to 2.0.0.