### PR TITLE
Use object-assign instead of lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _ = require('lodash');
+var assign = require('object-assign');
 var loaderUtils = require('loader-utils');
 var elmCompiler = require('node-elm-compiler');
 
@@ -18,7 +18,7 @@ var getInput = function() {
 var getOptions = function() {
   var globalOptions = this.options.elm || {};
   var loaderOptions = loaderUtils.parseQuery(this.query);
-  return _.extend({
+  return assign({
     emitWarning: this.emitWarning
   }, defaultOptions, globalOptions, loaderOptions);
 };

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "homepage": "https://github.com/rtfeldman/elm-webpack-loader",
   "dependencies": {
     "loader-utils": "^0.2.11",
-    "lodash": "^3.10.1",
-    "node-elm-compiler": "^3.0.0"
+    "node-elm-compiler": "^3.0.0",
+    "object-assign": "^4.0.1"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
Lodash is a pretty big project and we're only using it for a single function call. Let's use `object-assign` instead.

Considerations:
- We could get away with no deps if we make node version 4+ a requirement and use `Object.assign`
- We could also just include a polyfill in index.js (eg [MDN: Object.assign()](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign)

Anyway, thanks for making this loader! And for doing so much else for Elm :)