### PR TITLE
Bump to 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,14 @@ You can silence this warning with [noParse](https://webpack.github.io/docs/confi
     noParse: [/.elm$/]
   }
 ```
+
+## Revisions
+
+### 2.0.0
+
+Change `warn` to be a pass-through compiler flag rather than a way to specify
+logging behavior.
+
+### 1.0.0
+
+Initial stable release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-webpack-loader",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Webpack loader for the Elm programming language.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-webpack-loader",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Webpack loader for the Elm programming language.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
@joeandaverde @eeue56 this is the resolution to https://github.com/rtfeldman/elm-webpack-loader/pull/40#issuecomment-192689033 that makes sense to me. (I have no idea why `master` was on `1.x` when a `2.x` version had already been published.)

Does this seem reasonable?

Edit: should fix #30