### PR TITLE
preparatory update for 0.17

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ var cachedDependencies = [];
 
 var defaultOptions = {
   cache: false,
-  yes: true
+  yes: true,
+  appendExport: false
 };
 
 var getInput = function() {
@@ -52,7 +53,12 @@ module.exports = function() {
   Promise.all([dependencies, compilation])
     .then(function(results) {
       var output = results[1]; // compilation output
-      callback(null, output);
+      if (options.appendExport) {
+        var outputWithExport = [output, 'module.exports = Elm;'].join('\n');
+        callback(null, outputWithExport);
+      } else {
+        callback(null, output);
+      }
     })
     .catch(function(err) {
       callback('Compiler process exited with error ' + err);

--- a/index.js
+++ b/index.js
@@ -52,8 +52,7 @@ module.exports = function() {
   Promise.all([dependencies, compilation])
     .then(function(results) {
       var output = results[1]; // compilation output
-      var resultWithExports = [output, 'module.exports = Elm;'].join('\n');
-      callback(null, resultWithExports);
+      callback(null, output);
     })
     .catch(function(err) {
       callback('Compiler process exited with error ' + err);

--- a/test/loader.js
+++ b/test/loader.js
@@ -22,7 +22,7 @@ var hash = function (data) {
 var compile = function (filename) {
   return compiler.compileToString([filename], {yes: true, cwd: fixturesDir})
     .then(function (data) {
-      return [data.toString(), 'module.exports = Elm;'].join('\n');
+      return data.toString();
     });
 }
 


### PR DESCRIPTION
0.17 compilation output seems to include its own UMD wrapper so manually assigning to `module.exports` ends up not being necessary and also throws because `Elm` is never added to the global namespace

thanks!