### PR TITLE
Obtain path to elm file without query

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var defaultOptions = {
 };
 
 var getInput = function() {
-  return loaderUtils.getRemainingRequest(this);
+  return this.resourcePath;
 };
 
 var getOptions = function() {


### PR DESCRIPTION
Use `resourcePath` instead of `getRemainingRequest` to obtain absolute path to elm entry point.

Using the `getRemainingRequest` caused an error when this loader is used with any other loader (when the loaderContext.loaders array contains more loaders than just elm-webpack-loader).

Also, I noticed that tests actually mock `resourcePath` and leave `loaders` as an empty array:
https://github.com/rtfeldman/elm-webpack-loader/blob/master/test/loader.js#L40
