### PR TITLE
Pass a real error object to webpack on failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ module.exports = function() {
       callback(null, output);
     })
     .catch(function(err) {
-      callback('Compiler process exited with error ' + err);
+      err.message = 'Compiler process exited with error ' + err.message;
+      callback(err);
     });
 }


### PR DESCRIPTION
This preserves the error information when webpack produces the failure output, as it's expecting an error object, not a string.

This is the companion piece to https://github.com/rtfeldman/node-elm-compiler/pull/28 - I must have forgotten I'd made the local change to make this work.