### PR TITLE
Fixed a race condition between dependency analysis and error reporting

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,16 +47,18 @@ module.exports = function() {
       }
     }.bind(this));
 
-  var compilation = elmCompiler.compileToString(input, options);
+  var compilation = elmCompiler.compileToString(input, options)
+    .then(function(v) { return { kind: 'success', result: v }; })
+    .catch(function(v) { return { kind: 'error', error: v }; });
 
   Promise.all([dependencies, compilation])
     .then(function(results) {
       var output = results[1]; // compilation output
-
-      callback(null, output);
-    })
-    .catch(function(err) {
-      err.message = 'Compiler process exited with error ' + err.message;
-      callback(err);
+      if (output.kind == 'success') {
+        callback(null, output.result);
+      } else {
+        output.error.message = 'Compiler process exited with error ' + output.error.message;
+        callback(output.error);
+      }
     });
 }


### PR DESCRIPTION
The issue is that Promise.all is fail-fast. This means that if compiler bails out with an error then Promise.all invokes .catch branch without waiting for dependency analysis to complete. If dependency analysis takes more time than actual compilation, then error gets reported to webpack before addDependency calls are made. So webpack thinks that there are no dependencies and doesn't detect changes in modules other than primary input.

I believe this is related at least to #56, #30, moarwick/elm-webpack-starter#3.