### PR TITLE
Add webpack dependencies by recursively finding all .elm files

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "homepage": "https://github.com/rtfeldman/elm-webpack-loader",
   "dependencies": {
     "loader-utils": "^0.2.11",
-    "node-elm-compiler": "4.1.1"
+    "node-elm-compiler": "4.1.1",
+    "readdirp": "^2.1.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/test/fixtures/Bad.elm
+++ b/test/fixtures/Bad.elm
@@ -1,3 +1,3 @@
-module Bad where
+module Bad exposing (..)
 
 add x y = x +

--- a/test/fixtures/Good.elm
+++ b/test/fixtures/Good.elm
@@ -1,4 +1,4 @@
-module Good where
+module Good exposing (..)
 
 import GoodDependency exposing ( add )
 

--- a/test/fixtures/GoodDependency.elm
+++ b/test/fixtures/GoodDependency.elm
@@ -1,3 +1,3 @@
-module GoodDependency where
+module GoodDependency exposing (..)
 
 add x y = x + y

--- a/test/fixtures/elm-package.json
+++ b/test/fixtures/elm-package.json
@@ -9,7 +9,8 @@
   "exposed-modules": [
   ],
   "dependencies": {
-    "elm-lang/core": "3.0.0 <= v < 4.0.0"
+      "elm-lang/core": "4.0.5 <= v < 5.0.0",
+      "elm-lang/html": "1.1.0 <= v < 2.0.0"
   },
-  "elm-version": "0.16.0 <= v < 0.17.0"
+  "elm-version": "0.17.1 <= v < 0.18.0"
 }


### PR DESCRIPTION
Rather than using the findAllDepencies method of node-elm-compiler, this loader simply recursively finds all .elm files stemming from the current directory, exluding the elm-stuff, .git, and node_modules dirs.

I created this specifically to solve this issue I was having: https://github.com/rtfeldman/elm-webpack-loader/issues/63.

This pull request is just an idea, and an immediate fix to the problem I was having. The tests pass, but I'm not completely sure if there aren't any potential problems with the approach.

