### PR TITLE
add a limit to running processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,31 @@ See the [examples](#example) section below for the complete webpack configuratio
 
 ### Options
 
+#### cwd (default null) *Recommended*
+
+You can add `cwd=elmSource` to the loader:
+```js
+var elmSource = __dirname + '/elm/path/in/project'
+  ...
+  loader: 'elm-webpack?cwd=' + elmSource
+  ...
+```
+
+You can use this to specify a custom location within your project for your elm files. Note, this
+will cause the compiler to look for **all** elm source files in the specified directory. This approach is recommended as it allows the compile to watch elm-package.json as well as every file in the source directories.
+
+#### maxInstances (default 4)
+
+You can add `cache=true` to the loader:
+
+```js
+  ...
+  loader: 'elm-webpack?maxInstances=8'
+  ...
+```
+
+Set a limit to the number of maxInstances of elm that can spawned. This should be set to a number less than the number of cores your machine has
+
 #### Cache (default false)
 
 You can add `cache=true` to the loader:
@@ -52,18 +77,6 @@ new files won't be picked up and so won't be watched until you restart webpack.
 
 This flag doesn't matter if you don't use watch mode.
 
-#### cwd (default null)
-
-You can add `cwd=elmSource` to the loader:
-```js
-var elmSource = __dirname + '/elm/path/in/project'
-  ...
-  loader: 'elm-webpack?cwd=' + elmSource
-  ...
-```
-
-You can use this to specify a custom location within your project for your elm files. Note, this
-will cause the compiler to look for **all** elm source files in the specified directory.
 
 #### Upstream options
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var yargs = require('yargs');
 
 var cachedDependencies = [];
 var cachedDirDependencies = [];
+var runningInstances = 0;
 
 var defaultOptions = {
   cache: false,
@@ -74,12 +75,7 @@ module.exports = function() {
 
   var input = getInput.call(this);
   var options = getOptions.call(this);
-
-  var compilation = elmCompiler.compileToString(input, options)
-    .then(function(v) { return { kind: 'success', result: v }; })
-    .catch(function(v) { return { kind: 'error', error: v }; });
-
-  var promises = [compilation];
+  var promises = [];
 
   // we only need to track deps if we are in watch mode
   // otherwise, we trust elm to do it's job
@@ -87,7 +83,8 @@ module.exports = function() {
     // we can do a glob to track deps we care about if cwd is set
     if (typeof options.cwd !== "undefined" && options.cwd !== null){
       // watch elm-package.json
-      addDependencies.bind(this)([path.join(options.cwd, "elm-package.json")]);
+      var elmPackage = path.join(options.cwd, "elm-package.json");
+      addDependencies.bind(this)([elmPackage]);
       var dirs = filesToWatch(options.cwd);
       // watch all the dirs in elm-package.json
       addDirDependency.bind(this)(dirs);
@@ -105,15 +102,36 @@ module.exports = function() {
     }
   }
 
+  var maxInstances = options.maxInstances;
 
-  Promise.all(promises)
-    .then(function(results) {
-      var output = results[0]; // compilation output
-      if (output.kind == 'success') {
-        callback(null, output.result);
-      } else {
-        output.error.message = 'Compiler process exited with error ' + output.error.message;
-        callback(output.error);
-      }
-    });
+  if (typeof maxInstances === "undefined"){
+    maxInstances = 4;
+  } else {
+    delete options.maxInstances;
+  }
+
+  var intervalId = setInterval(function(){
+    if (runningInstances > maxInstances) return;
+    runningInstances += 1;
+    clearInterval(intervalId);
+
+    var compilation = elmCompiler.compileToString(input, options)
+      .then(function(v) { runningInstances -= 1; return { kind: 'success', result: v }; })
+      .catch(function(v) { return { kind: 'error', error: v }; });
+
+    promises.push(compilation);
+
+    Promise.all(promises)
+      .then(function(results) {
+        var output = results[0]; // compilation output
+
+        if (output.kind == 'success') {
+          callback(null, output.result);
+        } else {
+          output.error.message = 'Compiler process exited with error ' + output.error.message;
+          callback(output.error);
+        }
+      });
+
+  }, 200);
 }


### PR DESCRIPTION
- prevents compilers competing
- limiting to 1 process per loader can avoid deadlocks