### PR TITLE
Pass main file compile result to next loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ module.exports = function() {
 
     Promise.all(promises)
       .then(function(results) {
-        var output = results[0]; // compilation output
+        var output = results[results.length - 1]; // compilation output
 
         if (output.kind == 'success') {
           callback(null, output.result);


### PR DESCRIPTION
Dependency result is
```
{ kind: 'success', result: undefined }
```
This causes elm-webpack-loader to pass undefined to the loader callback.

Fix #85